### PR TITLE
change mask value of year from 0 to 1901

### DIFF
--- a/core/src/main/java/org/shadowmask/core/mask/rules/generalizer/impl/TimestampGeneralizer.java
+++ b/core/src/main/java/org/shadowmask/core/mask/rules/generalizer/impl/TimestampGeneralizer.java
@@ -113,7 +113,7 @@ public class TimestampGeneralizer implements Generalizer<Long, Long> {
         dateTime = dateTime.hourOfDay().setCopy(0);
         dateTime = dateTime.dayOfMonth().setCopy(1);
         dateTime = dateTime.monthOfYear().setCopy(1);
-        dateTime = dateTime.year().setCopy(0);
+        dateTime = dateTime.year().setCopy(1901);
         break;
       }
 

--- a/core/src/test/java/com/shadowmask/core/mask/rules/generalization/TimeStampGeneralizerTest.java
+++ b/core/src/test/java/com/shadowmask/core/mask/rules/generalization/TimeStampGeneralizerTest.java
@@ -66,7 +66,7 @@ public class TimeStampGeneralizerTest {
         long expected6 = DateTime.parse("2016-01-01T00:00:00.000").getMillis();
         assertEquals(expected6, generated6);
         long generated7 = generalization.generalize(timestamp, 7);
-        long expected7 = DateTime.parse("0000-01-01T00:00:00.000").getMillis();
+        long expected7 = DateTime.parse("1901-01-01T00:00:00.000").getMillis();
         assertEquals(expected7, generated7);
     }
 }

--- a/engine/hive-engine/src/test/java/org/shadowmask/engine/hive/udf/UDFTimestampTest.java
+++ b/engine/hive-engine/src/test/java/org/shadowmask/engine/hive/udf/UDFTimestampTest.java
@@ -85,7 +85,7 @@ public class UDFTimestampTest {
     assertEquals(expect6, result.getTimestamp().getTime());
     mask.set(7);
     result = udfTimestamp.evaluate(timestamp, mask);
-    long expect7 = DateTime.parse("0000-01-01T00:00:00.000").getMillis();
+    long expect7 = DateTime.parse("1901-01-01T00:00:00.000").getMillis();
     assertEquals(expect7, result.getTimestamp().getTime());
 
     timestamp = null;


### PR DESCRIPTION
As described in title, the original masked value of year as zero doesn't perform correctly through test. It is changed to 1901, so the result of mask level 7 will be 1901-01-01T00:00:00.000. 